### PR TITLE
Add support for all openapi3 reusable components

### DIFF
--- a/examples/colors_openapi3_with_components.py
+++ b/examples/colors_openapi3_with_components.py
@@ -1,0 +1,81 @@
+"""
+The simple example using declared definitions with reusable components.
+"""
+
+from flask import Flask, jsonify
+
+from flasgger import Swagger, utils
+
+app = Flask(__name__)
+app.config['SWAGGER'] = {
+    'title': 'Colors API',
+    "openapi": "3.0.2",
+}
+Swagger(app)
+
+
+@app.route('/colors/<palette>/')
+def colors(palette):
+    """Example endpoint return a list of colors by palette
+    This is using docstring for specifications
+    ---
+    tags:
+      - colors
+    parameters:
+      - $ref: "#/components/parameters/PaletteParameter"
+    components:
+      schemas:
+        Palette:
+          type: object
+          properties:
+            palette_name:
+              type: array
+              items:
+                $ref: '#/components/schemas/Color'
+        Color:
+          type: string
+      parameters:
+        PaletteParameter:
+          in: path
+          type: string
+          enum: ['all', 'rgb', 'cmyk']
+          required: true
+          default: all
+          description: Which palette to filter?
+    responses:
+      200:
+        description: A list of colors (may be filtered by palette)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Palette'
+            examples:
+              rgb: ['red', 'green', 'blue']
+    """
+    all_colors = {
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
+        'rgb': ['red', 'green', 'blue']
+    }
+    if palette == 'all':
+        result = all_colors
+    else:
+        result = {palette: all_colors.get(palette)}
+
+    return jsonify(result)
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    for url, spec in specs_data.items():
+        assert 'Palette' in spec['components']['schemas']
+        assert 'Color' in spec['components']['schemas']
+        assert 'PaletteParameter' in spec['components']['parameters']
+        assert 'colors' in spec['paths']['/colors/{palette}/']['get']['tags']
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -32,7 +32,9 @@ except ImportError:
     RequestParser = None
 import jsonschema
 from mistune import markdown
-from .constants import OPTIONAL_FIELDS, OPTIONAL_OAS3_FIELDS
+from .constants import OAS3_SUB_COMPONENTS
+from .constants import OPTIONAL_FIELDS
+from .constants import OPTIONAL_OAS3_FIELDS
 from .utils import LazyString
 from .utils import extract_definitions
 from .utils import get_schema_specs
@@ -447,31 +449,14 @@ class Swagger(object):
                 if is_openapi3(openapi_version):
                     source_components = swag.get('components', {})
                     update_schemas = source_components.get('schemas', {})
-                    merge_sub_component(data['components'], 'parameters',
-                                        source_components.get('parameters',
-                                        {}))
-                    merge_sub_component(data['components'], 'securitySchemes',
-                                        source_components.get(
-                                            'securitySchemes',
-                                        {}))
-                    merge_sub_component(data['components'], 'requestBodies',
-                                        source_components.get('requestBodies',
-                                        {}))
-                    merge_sub_component(data['components'], 'responses',
-                                        source_components.get('responses',
-                                        {}))
-                    merge_sub_component(data['components'], 'headers',
-                                        source_components.get('headers',
-                                        {}))
-                    merge_sub_component(data['components'], 'examples',
-                                        source_components.get('examples',
-                                        {}))
-                    merge_sub_component(data['components'], 'links',
-                                        source_components.get('links',
-                                        {}))
-                    merge_sub_component(data['components'], 'callbacks',
-                                        source_components.get('callbacks',
-                                        {}))
+                    # clone list so we can modify
+                    active_sub_components = OAS3_SUB_COMPONENTS[:]
+                    # schemas are handled separately, so remove them here
+                    active_sub_components.remove("schemas")
+                    for subcomponent in OAS3_SUB_COMPONENTS:
+                        merge_sub_component(data['components'], subcomponent,
+                                            source_components.get(subcomponent,
+                                            {}))
                 else:  # openapi2
                     update_schemas = swag.get('definitions', {})
 

--- a/flasgger/constants.py
+++ b/flasgger/constants.py
@@ -7,6 +7,11 @@ OPTIONAL_OAS3_FIELDS = [
     'components', 'servers'
 ]
 
+OAS3_SUB_COMPONENTS = [
+    "parameters", "securitySchemes", "requestBodies", "responses",
+    "headers", "examples", "links", "callbacks", "schemas"
+]
+
 DEFAULT_FIELDS = {"tags": [], "consumes": ['application/json'],
                   "produces": ['application/json'], "schemes": [],
                   "security": [], "deprecated": False, "operationId": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyYAML>=3.0
 jsonschema>=3.0.1
 six>=1.10.0
 mistune
-werkzeug
+werkzeug==2.0.2


### PR DESCRIPTION
This add support for reusable components beyond schema from the openapi3 spec, e.g. https://swagger.io/docs/specification/components/. We need this to make reusable paging and filtering parameters for our get-list endpoints. 