### PR TITLE
json-encoder-hack

### DIFF
--- a/examples/lazy_string.py
+++ b/examples/lazy_string.py
@@ -4,12 +4,9 @@ Test the use of LazyString to populate a template at runtime.
 
 from flask import Flask, jsonify, request
 
-from flasgger import Swagger, LazyString, LazyJSONEncoder
+from flasgger import Swagger, LazyString
 
 app = Flask(__name__)
-
-# Set the LAzyString JSON Encoder
-app.json_encoder = LazyJSONEncoder
 
 app.config['SWAGGER'] = {
     'uiversion': 2

--- a/flasgger/__init__.py
+++ b/flasgger/__init__.py
@@ -7,7 +7,7 @@ __email__ = 'billrao@me.com'
 
 
 from jsonschema import ValidationError  # noqa
-from .base import Swagger, Flasgger, NO_SANITIZER, BR_SANITIZER, MK_SANITIZER, LazyJSONEncoder  # noqa
+from .base import Swagger, Flasgger, NO_SANITIZER, BR_SANITIZER, MK_SANITIZER  # noqa
 from .utils import swag_from, validate, apispec_to_template, LazyString  # noqa
 from .marshmallow_apispec import APISpec, SwaggerView, Schema, fields  # noqa
 from .constants import OPTIONAL_FIELDS  # noqa

--- a/flasgger/__init__.py
+++ b/flasgger/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.9.5'
+__version__ = '0.9.5.1'
 __author__ = 'Zixuan Rao'
 __email__ = 'billrao@me.com'
 

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -29,7 +29,6 @@ try:
     from flask_restful.reqparse import RequestParser
 except ImportError:
     RequestParser = None
-from json import JSONEncoder
 import jsonschema
 from mistune import markdown
 from .constants import OAS3_SUB_COMPONENTS
@@ -911,10 +910,3 @@ class Swagger(object):
 
 # backwards compatibility
 Flasgger = Swagger  # noqa
-
-
-class LazyJSONEncoder(JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, LazyString):
-            return str(obj)
-        return super(LazyJSONEncoder, self).default(obj)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -25,11 +25,11 @@ from flask import render_template
 from flask import request, url_for
 from flask import abort
 from flask.views import MethodView
-from flask.json import JSONEncoder
 try:
     from flask_restful.reqparse import RequestParser
 except ImportError:
     RequestParser = None
+from json import JSONEncoder
 import jsonschema
 from mistune import markdown
 from .constants import OAS3_SUB_COMPONENTS


### PR DESCRIPTION
newer versions of `flask` no longer have `JSONEncoder` or `LazyJSONEncoder`...